### PR TITLE
Use unsigned int for bitshift

### DIFF
--- a/lgmp/src/client.c
+++ b/lgmp/src/client.c
@@ -184,8 +184,8 @@ LGMP_STATUS lgmpClientSubscribe(PLGMPClient client, uint32_t queueID,
     uint32_t reap = 0;
     for(unsigned int id = 0; id < 32; ++id)
     {
-      if ((LGMP_SUBS_BAD(subs) & (1 << id)) && hosttime > hq->timeout[id])
-        reap |= (1 << id);
+      if ((LGMP_SUBS_BAD(subs) & (1U << id)) && hosttime > hq->timeout[id])
+        reap |= (1U << id);
     }
     subs = LGMP_SUBS_CLEAR(subs, reap);
   }


### PR DESCRIPTION
This fixes the below UBSan report:

```
/code/LookingGlass/repos/LGMP/lgmp/src/client.c:187:37: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
```