### PR TITLE
Fix use of incorrect index variable in lgmpHostGetClientIDs

### DIFF
--- a/lgmp/src/host.c
+++ b/lgmp/src/host.c
@@ -428,7 +428,7 @@ LGMP_STATUS lgmpHostGetClientIDs(PLGMPHostQueue queue, uint32_t clientIDs[32],
   {
     const uint32_t bit = 1U << i;
     if (!(LGMP_SUBS_ON(subs) & bit) ||
-        ((LGMP_SUBS_BAD(subs) & bit) && now > hq->timeout[bit]))
+        ((LGMP_SUBS_BAD(subs) & bit) && now > hq->timeout[i]))
       continue;
 
     clientIDs[(*count)++] = hq->clientID[i];


### PR DESCRIPTION
Looks like there's a bug in lgmpHostGetClientIds where it attempts to access the timeout array using the bitmask as an index, which could cause out-of-bounds memory accesses for higher client ID values.